### PR TITLE
Jenkinsfile: surround pwsh script arguments by quotes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,8 @@ pipeline {
     stages {
         stage ('stage1') {
             steps {
+                echo "${params.in_disks}"
+                echo "${params.in_servername}"
                 pwsh ".\\test1.ps1 ${params.in_disks} ${params.in_servername}"
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     stages {
         stage ('stage1') {
             steps {
-                pwsh ".\\test1.ps1 ${params.in_disks} ${params.in_servername}"
+                pwsh ".\\test1.ps1 '${params.in_disks}' '${params.in_servername}'"
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,8 +5,6 @@ pipeline {
     stages {
         stage ('stage1') {
             steps {
-                echo "${params.in_disks}"
-                echo "${params.in_servername}"
                 pwsh ".\\test1.ps1 ${params.in_disks} ${params.in_servername}"
             }
         }

--- a/test1.ps1
+++ b/test1.ps1
@@ -1,7 +1,9 @@
-param ($in_disks, $serverName)
+param ($in_disks, $in_serverName)
 
 $script = {
-    #$in_disks
+    $in_disks
+    $in_serverName
+
     $diskArray = $in_disks | ConvertFrom-Json
     $diskArray
     $dataDisks = $diskArray.where{($_.label -ne "C")}
@@ -24,4 +26,4 @@ $script = {
     }
 }
 
-Invoke-Command -ScriptBlock $script -ArgumentList $in_disks, $serverName
+Invoke-Command -ScriptBlock $script -ArgumentList $in_disks, $in_serverName


### PR DESCRIPTION
Jenkinsfile: surround pwsh script arguments by quotes.
Required to keep the JSON data string intact.

Change the input parameter names: all need to be prefixed w/ 'in_'.